### PR TITLE
Updated language in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ $ npm install alex --global
 *   [FAQ](#faq)
 
     *   [Why is this named alex?](#why-is-this-named-alex)
-    *   [Alex didn’t check ‘X’, this is dumb!](#alex-didnt-check-x-this-is-dumb)
+    *   [Alex didn’t check ‘X’!](#alex-didnt-check-x)
 
 *   [Contributing](#contributing)
 
@@ -189,9 +189,9 @@ as follows:
 
 It’s a nice androgynous/unisex name, it was free on npm, I like it! :smile:
 
-### Alex didn’t check ‘X’, this is dumb!
+### Alex didn’t check ‘X’!
 
-This is not a question, and I don’t agree. See
+See
 [CONTRIBUTING.md](CONTRIBUTING.md) on how to get ‘X’ checked by alex.
 
 <!--lint enable no-heading-punctuation-->


### PR DESCRIPTION
The word "dumb" is often meant as synonymous to "stupid", but was originally used to refer to people with speech impairments and is still offensive to people with speech impairments. See: http://www.autistichoya.com/p/ableist-words-and-terms-to-avoid.html

Also yes, I am Alex, and it's amusing that I caught and modified this file manually.