### PR TITLE
Add Visual Studio Code extension to the integrations section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,7 @@ alex.text('The `boogeyman`.').messages;
 
 *   Atom — [wooorm/atom-linter-alex](https://github.com/wooorm/atom-linter-alex)
 *   Sublime — [sindresorhus/SublimeLinter-contrib-alex](https://github.com/sindresorhus/SublimeLinter-contrib-alex)
+*   Visual Studio Code — [shinnn/vscode-alex](https://github.com/shinnn/vscode-alex)
 *   Gulp — [dustinspecker/gulp-alex](https://github.com/dustinspecker/gulp-alex)
 *   Slack — [keoghpe/alex-slack](https://github.com/keoghpe/alex-slack)
 


### PR DESCRIPTION
I just published a [Visual Studio Code](https://code.visualstudio.com/) extension.

https://github.com/shinnn/vscode-alex
https://marketplace.visualstudio.com/items/shinnn.alex

I added it to the third line because the existing integration tools seems to be listed in [editors] - [others] order. If the new one should be in the last line, I'll update the commit.
