### PR TITLE
Update ava and nyc

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "vfile-sort": "^1.0.0"
   },
   "devDependencies": {
-    "ava": "^0.5.0",
+    "ava": "^0.7.0",
     "browserify": "^12.0.1",
     "eslint": "^1.0.0",
     "esmangle": "^1.0.1",
@@ -68,7 +68,7 @@
     "mdast-lint": "^1.0.0",
     "mdast-toc": "^1.0.0",
     "mdast-validate-links": "^1.0.0",
-    "nyc": "^3.2.2"
+    "nyc": "^4.0.1"
   },
   "scripts": {
     "test-api": "ava",

--- a/test.js
+++ b/test.js
@@ -35,20 +35,14 @@ test('alex()', function (t) {
         '3:1-3:3: `he` may be insensitive, use `they`, `it` instead',
         '3:10-3:17: `cripple` may be insensitive, use `person with a limp` instead'
     ]);
-
-    t.end();
 });
 
 test('alex.markdown()', function (t) {
     t.same(alex.markdown('The `boogeyman`.').messages.map(String), []);
-
-    t.end();
 });
 
 test('alex.text()', function (t) {
     t.same(alex.text('The `boogeyman`.').messages.map(String), [
         '1:6-1:15: `boogeyman` may be insensitive, use `boogey` instead'
     ]);
-
-    t.end();
 });


### PR DESCRIPTION
Especially, https://github.com/sindresorhus/ava/releases/tag/v0.7.0:

> You no longer have to call `t.end()` in synchronous tests.