### PR TITLE
Ignore .nyc_output instead of coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ bower_components/
 build/
 components/
 node_modules/
-coverage/
+.nyc_output/
 build.js


### PR DESCRIPTION
Because you replaced [istanbul](https://github.com/gotwarlost/istanbul) with [nyc](https://github.com/bcoe/nyc) in https://github.com/wooorm/alex/commit/9af5eef35b54ac9a8a5252021292a05d61200bbc.

`nyc` don't create `coverage` directory but `.nyc_output` directory.
