### PR TITLE
default to empty of object if alex settings are not defined in package.json

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -336,7 +336,7 @@ globby(globs).then(function (filePaths) {
                     contents = JSON.parse(file.contents);
 
                     if (file.basename() === PACKAGE) {
-                        contents = contents[PACKAGE_FIELD];
+                        contents = contents[PACKAGE_FIELD] || {};
                     }
 
                     allow = [].concat.apply(allow, contents.allow);


### PR DESCRIPTION
@wooorm was running into this issue when i didn't define settings in package or in `.alexrc`

<img width="781" alt="screen shot 2016-02-08 at 11 46 57 pm" src="https://cloud.githubusercontent.com/assets/8263298/12907859/6ee23dfc-cebe-11e5-9a1d-75669e9ebc9f.png">
