### PR TITLE
upgrade minor version of retext-equality dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "remark-parse": "^5.0.0",
     "remark-retext": "^3.0.0",
     "retext-english": "^3.0.0",
-    "retext-equality": "~3.3.0",
+    "retext-equality": "~3.4.0",
     "retext-profanities": "~4.4.0",
     "unified": "^7.0.0",
     "unified-diff": "^2.0.0",


### PR DESCRIPTION
This PR updates a dependency to use the latest [minor release](https://github.com/retextjs/retext-equality/releases/tag/3.4.0) of `retext-equality`. With this change, the "make * great again" pattern is caught as insensitive in `alex` itself too.

This is a followup to a [previous PR](https://github.com/retextjs/retext-equality/pull/42) merged in `retext-equality`.