### PR TITLE
Add w0rp/ale to integrations

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -162,6 +162,7 @@ were read-only copies of master. But not to worry, he was a cripple.</code></pre
         <li>Slack: <a href="https://github.com/keoghpe/alex-slack">alex-slack</a> (by <a href="https://github.com/keoghpe">@keoghpe</a>)</li>
         <li>Ember: <a href="https://github.com/yohanmishkin/ember-cli-alex">ember-cli-alex</a> (by <a href="https://github.com/yohanmishkin">@yohanmishkin</a>)</li>
         <li>Probot: <a href="https://github.com/swinton/linter-alex">linter-alex</a> (by <a href="https://github.com/swinton">@swinton</a>)</li>
+        <li>Vim: <a href="https://github.com/w0rp/ale">ALE</a> (by <a href="https://github.com/w0rp">@w0rp</a>)</li>
       </ul>
     </section>
     <section class="section content">


### PR DESCRIPTION
`Closes #191`

It is worth noting that unlike the other items in the Integrations section, ALE is not alex-specific.